### PR TITLE
Make the manifest url always point to the latest release

### DIFF
--- a/module.json
+++ b/module.json
@@ -18,7 +18,7 @@
   "minimumCoreVersion": "0.8.6",
   "compatibleCoreVersion": "9.238",
   "url": "https://github.com/1000nettles/hey-wait",
-  "manifest": "https://github.com/1000nettles/hey-wait/releases/download/v0.6.3/module.json",
+  "manifest": "https://github.com/1000nettles/hey-wait/releases/latest/download/module.json",
   "download": "https://github.com/1000nettles/hey-wait/releases/download/v0.6.3/hey-wait-v0.6.3.zip",
   "license": "MIT",
   "readme": "https://raw.githubusercontent.com/1000nettles/hey-wait/main/README.md"


### PR DESCRIPTION
This PR adjusts the `module.json` to make it work smoother with foundries updater.

This is how the updater works:
1. It opens the `module.json` that is stored in the local module folder
2. It downloads the manifest from the URL that's listed under the `manifest` key
3. In the downloaded manifest the updater will check the `version` field
4. If the version is newer than what's currently installed, the updater will download the zip file indicated by `download` and installs what was downloaded.

For "Hey, Wait!" this process fails at step 4. Because the `manifest`-value points to the release that is currently installed (0.6.3 right now) the downloaded manifest will always have the same version and the updater detects that there's no update necessary.

There is a fallback mechanism in foundry however: If the above process indicates that there's no update available, foundry will check if the module browser indicates a new version. If so, foundry assumes that the module has been moved to a different repository and will ask the user whether they'd like to use that new software repository instead of the one that's indicated by the current installation. Thanks to this fallback mechanism, updating "Hey, wait!" still works. However, users have to confirm a dialog box every time the module receives an update.

This PR changes the `manifest` key to always point to the latest release (instead of any concrete version number). This allows the updater to work as laid out above. As a result the user will no longer need to confirm a dialog box when updating the module. Additionally, there's one less value to update in the manifest when releasing new versions. 